### PR TITLE
Add initial API docs

### DIFF
--- a/resources/docs/index.md
+++ b/resources/docs/index.md
@@ -1,0 +1,13 @@
+# Getting Started
+
+This documentation contains examples for interacting with the AdminHot API.
+
+## Authentication
+
+Most endpoints require authentication via a bearer token. Retrieve your personal access token from your profile or via the login endpoints. Send the token in the `Authorization` header with the `Bearer` scheme:
+
+```
+Authorization: Bearer YOUR_TOKEN_HERE
+```
+
+Requests missing or using an invalid token will receive `401 Unauthorized`.

--- a/resources/docs/intro.md
+++ b/resources/docs/intro.md
@@ -1,0 +1,10 @@
+# API Overview
+
+Welcome to the AdminHot API. This API provides programmatic access to most features of the platform.
+
+- **Base URL:** `/api`
+- **Format:** JSON by default for both requests and responses.
+- **Status codes:** Standard HTTP response codes are used to indicate success or failure.
+- **Parameters:** Send as JSON in the body for POST/PUT/PATCH requests or as query parameters for GET requests.
+
+Refer to each endpoint description for required parameters and response details.


### PR DESCRIPTION
## Summary
- create `resources/docs` directory with API introduction
- outline API usage and authentication in `intro.md` and `index.md`

## Testing
- `php -v` *(fails: command not found)*
- `composer install --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d1f048dc8321b3fb872d0f62d70d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added new introductory and getting started guides for the AdminHot API, covering authentication requirements, API base URL, data formats, HTTP status codes, and request parameter guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->