### PR TITLE
Add docs script and workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,14 @@
+name: Generate docs
+on: [push]
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Generate docs
+        run: composer docs

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
         ],
-        "pre-autoload-dump": "Google\\Task\\Composer::cleanup"
+        "pre-autoload-dump": "Google\\Task\\Composer::cleanup",
+        "docs": "php artisan scribe:generate"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
## Summary
- add a `docs` composer script that runs Scribe
- automate docs generation in a GitHub Actions workflow

## Testing
- `composer validate --no-check-all` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d27445a88321a99ea238273e850c