### PR TITLE
Add Laravel Collective HTML integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/browser-kit": "^7.0",
         "symfony/dom-crawler": "^7.0",
         "symfony/http-client": "^7.0",
-        "twilio/sdk": "^8.6"
+        "twilio/sdk": "^8.6",
+        "laravelcollective/html": "^9.0"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.15",

--- a/config/app.php
+++ b/config/app.php
@@ -198,7 +198,7 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
-        //Collective\Html\HtmlServiceProvider::class,
+        Collective\Html\HtmlServiceProvider::class,
         Spatie\Permission\PermissionServiceProvider::class,
         \App\Providers\ViewServiceProvider::class,
 
@@ -216,11 +216,11 @@ return [
     |
     */
 
-    /*'aliases' => Facade::defaultAliases()->merge([
+    'aliases' => Facade::defaultAliases()->merge([
         // 'ExampleClass' => App\Example\ExampleClass::class,
-        'Form'     => Collective\Html\FormFacde::class,
-        'html'     => Collective\Html\HtmlFacde::class,
+        'Form'     => Collective\Html\FormFacade::class,
+        'Html'     => Collective\Html\HtmlFacade::class,
         'Paystack' => Unicodeveloper\Paystack\Facades\Paystack::class,
-    ])->toArray(),*/
+    ])->toArray(),
 
 ];


### PR DESCRIPTION
## Summary
- install `laravelcollective/html` package
- register `HtmlServiceProvider`
- enable aliases for Form and Html facades

## Testing
- `composer update laravelcollective/html --no-interaction --no-progress` *(fails: composer not found)*
- `php artisan config:clear` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e2b8a7988321b50ea71dc674a432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for advanced HTML and form building features through the integration of the Laravel Collective HTML package.

- **Chores**
  - Updated configuration to enable new package and correct related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->